### PR TITLE
pin python-ldap version

### DIFF
--- a/requirements/compiled.txt
+++ b/requirements/compiled.txt
@@ -9,4 +9,5 @@ hashlib==20081119
 py-bcrypt==0.2
 
 mercurial==2.1.2
-python-ldap
+python-ldap==2.3.13
+


### PR DESCRIPTION
It has bitten me and Schalk more than once. I've been fixing it manually. Time to update the code. 

Could just be that the latest python-ldap on OSX doesn't work but does on RHEL. 

r?
