### PR TITLE
add android-multilocale as default value in platforms

### DIFF
--- a/apps/shipping/templates/shipping/about-milestone.html
+++ b/apps/shipping/templates/shipping/about-milestone.html
@@ -40,7 +40,7 @@
       <form id="changes.json" method="get" action="{% url 'shipping.views.milestone.json_changesets' %}">
       <input type="hidden" name="ms" value="{{ ms.code }}" />
       Platforms, comma separated:
-      <input type="text" name="platforms" value="android"><br>
+      <input type="text" name="platforms" value="android,android-multilocale"><br>
       <input type="button" value="Add" id="add-multi"> a multi-locale
       file for <input id="nextmulti"
       type="text" value="android-multilocale">


### PR DESCRIPTION
See bug 863334 – l10n shipping tools for a Fennec milestone should have android-multilocale in the default output of l10n-changesets.json
