### PR TITLE
Fix invalid HTML in the error500 template.

### DIFF
--- a/elmo/templates/500.html
+++ b/elmo/templates/500.html
@@ -12,5 +12,5 @@
     <p>...and we couldn't show you the page you requested. Sorry about that.</p>
     <p>If you wish to contact us about this error, feel free to send us an <a href="mailto:l10n@mozilla.com">e-mail</a> or ping us in <a href="irc://irc.mozilla.org/#elmo">#elmo</a>.</p>
     <h2>Feel like hacking?</h2>
-    <p>If you'd like to help us prevent others from seeing pages like this one, check out the <a href="https://bugzilla.mozilla.org/buglist.cgi?o1=isnotempty&amp;f1=bug_mentor&amp;resolution=---&amp;query_format=advanced&amp;component=Elmo&product=Webtools>list of mentored bugs</a> that we think can introduce you well to our codebase. Thanks!</p>
+    <p>If you'd like to help us prevent others from seeing pages like this one, check out the <a href="https://bugzilla.mozilla.org/buglist.cgi?o1=isnotempty&amp;f1=bug_mentor&amp;resolution=---&amp;query_format=advanced&amp;component=Elmo&amp;product=Webtools">list of mentored bugs</a> that we think can introduce you well to our codebase. Thanks!</p>
 {% endblock%}


### PR DESCRIPTION
The link is not even displayed as it is now!