### PR TITLE
Links to revs in Sign-off page have double //

### DIFF
--- a/apps/shipping/templates/shipping/signoff-rows.html
+++ b/apps/shipping/templates/shipping/signoff-rows.html
@@ -31,7 +31,7 @@
       {% endif %}
       <div class="rev">{{cs.description}}<br>
         <span class="csuser">{{cs.user}}</span>
-        <a href="{{push.url}}/rev/{{cs.shortrev}}" class="csuser">rev
+        <a href="{{push.url}}rev/{{cs.shortrev}}" class="csuser">rev
         <span class="shortrev" data-repo="{{push.repo}}">{{cs.shortrev}}</span></a>
       </div>
     </td>


### PR DESCRIPTION
Side note: links should really be visually identifiable without hovering them.