### PR TITLE
bug 1290906, resolve default or tip to the last known default changes…

### DIFF
--- a/apps/shipping/views/status.py
+++ b/apps/shipping/views/status.py
@@ -127,8 +127,16 @@ class JSONChangesets(SignoffDataView):
                 raise SuspiciousOperation("Repo %s doesn't exist" %
                                           str(props['repo']))
             try:
+                rev = str(props['rev'])
+                if rev in ('default', 'tip'):
+                    # let's not rely on the repo to have this right
+                    rev = (Changeset.objects
+                           .filter(repositories__name=props['repo'])
+                           .filter(branch=1)  # default branch
+                           .order_by('-pk')
+                           .values_list('revision', flat=True)[0])
                 locales = repo.cat(files=['path:'+str(props['path'])],
-                                   rev=str(props['rev'])).split()
+                                   rev=rev).split()
             finally:
                 repo.close()
             for loc in locales:


### PR DESCRIPTION
…et in the db, r?rail

Resolving 'default' is slow, and as soon as we use unified repos on elmo, also
wrong. Let's pick the last changeset of the default branch from the db, and use
an explicit version when talking to hg.
I'm also aliasing this to tip, which is not strictly true always, but it
shouldn't be used to begin with.
Better fix would be to just not have this code path at all, which is
bug 1280730.