### PR TITLE
bug 1372559 - update compare view to handle both json formats

### DIFF
--- a/apps/l10nstats/tests.py
+++ b/apps/l10nstats/tests.py
@@ -255,6 +255,28 @@ doc_v1 = {
 }
 
 
+doc_v2 = {
+    "_index": "elmo-comparisons",
+    "_type": "comparison",
+    "_id": "729457",
+    "_version": 1,
+    "_source": {
+        "run": 729457,
+        "details": {
+            "fr": {
+                "dom/chrome/dom/dom.properties": [
+                    {"missingEntity": "MozNoiseSuppressionWarning"},
+                    {"missingEntity": "MozAutoGainControlWarning"},
+                ],
+                "mobile/android/chrome/browser.properties": [
+                    {"missingEntity": "alertShutdownSanitize"},
+                ]
+            }
+        }
+    }
+}
+
+
 class TestCompareView(TestCase):
     def setUp(self):
         l10n = Forest.objects.create(
@@ -271,11 +293,18 @@ class TestCompareView(TestCase):
             id=doc_v1['_source']['run']
         )
 
-    def test_compare_view(self):
+    def test_compare_view_legacy(self):
 
         class View(l10nstats.views.CompareView):
             def get_doc(self, run):
                 return doc_v1['_source']
+        self._check_view(View)
+
+    def test_compare_view(self):
+
+        class View(l10nstats.views.CompareView):
+            def get_doc(self, run):
+                return doc_v2['_source']
         self._check_view(View)
 
     def _check_view(self, View):

--- a/apps/l10nstats/urls.py
+++ b/apps/l10nstats/urls.py
@@ -12,6 +12,6 @@ from . import views
 urlpatterns = [
     url(r'^$', views.index),
     url(r'^history$', views.history_plot, name='locale-tree-history'),
-    url(r'^compare$', views.compare, name='compare-locales'),
+    url(r'^compare$', views.CompareView.as_view(), name='compare-locales'),
     url(r'^tree-status/([^/]+)$', views.tree_progress, name='tree-history'),
 ]

--- a/apps/l10nstats/views.py
+++ b/apps/l10nstats/views.py
@@ -22,7 +22,7 @@ from django.db.models import Min, Max
 import json
 import elasticsearch
 
-from l10nstats.models import Active, Run
+from l10nstats.models import Run
 from life.models import Locale, Tree
 import shipping.views
 
@@ -77,13 +77,13 @@ def history_plot(request):
     locale = get_object_or_404(Locale, code=request.GET.get('locale'))
     highlights = defaultdict(dict)
     for param in sorted(
-        (p for p in request.GET.iterkeys() if p.startswith('hl-'))):
-            try:
-                _, i, kind = param.split('-')
-                i = int(i)
-            except:
-                continue
-            highlights[i][kind] = request.GET.get(param)
+            (p for p in request.GET.iterkeys() if p.startswith('hl-'))):
+        try:
+            _, i, kind = param.split('-')
+            i = int(i)
+        except:
+            continue
+        highlights[i][kind] = request.GET.get(param)
     for i, highlight in highlights.items():
         for k in ('s', 'e', 'c'):
             if k not in highlight:
@@ -111,13 +111,13 @@ def history_plot(request):
     except (KeyError, ValueError):
         starttime = endtime - timedelta(days=21)
     try:
-        r = q2.filter(srctime__lt=starttime).order_by('-srctime')[0]
+        run = q2.filter(srctime__lt=starttime).order_by('-srctime')[0]
         runs = [{
             'srctime': starttime,
-            'missing': r.allmissing + r.report,
-            'obsolete': r.obsolete,
-            'unchanged': r.unchanged,
-            'run': r.id
+            'missing': run.allmissing + run.report,
+            'obsolete': run.obsolete,
+            'unchanged': run.unchanged,
+            'run': run.id
             }]
     except IndexError:
         runs = []
@@ -252,11 +252,11 @@ class JSONAdaptor(object):
                 errors = [{'key': e, 'class': 'error'}
                           for e in self.value.get('error', [])]
                 warnings = [{'key': e, 'class': 'warning'}
-                          for e in self.value.get('warning', [])]
+                            for e in self.value.get('warning', [])]
                 entities = \
                     [{'key': e, 'class': 'missing'}
                      for e in self.value.get('missingEntity', [])] + \
-                     [{'key': e, 'class': 'obsolete'}
+                    [{'key': e, 'class': 'obsolete'}
                      for e in self.value.get('obsoleteEntity', [])]
                 entities.sort(key=lambda d: d['key'])
                 self.entities = errors + warnings + entities
@@ -309,7 +309,8 @@ def compare(request):
         else:
             doc = None
     if doc:
-        nodes = list(JSONAdaptor.adaptChildren(doc['details'].get('children', [])))
+        nodes = list(
+            JSONAdaptor.adaptChildren(doc['details'].get('children', [])))
     else:
         nodes = None
 


### PR DESCRIPTION
This is 4 commits, the first two are cosmetic cleanup, removing dead code and flaking.
Then I transform the compare view to a class-based view, so that I can insert testing json data by subclassing, and create a test.
Then I add a second variant to detect the new json format, and adapt it slightly differently in a way that works for the template.

Tested against a local setup with the new version of compare-locales, and missing/obsolete and errors all work.