### PR TITLE
bug 1442745 upgrade bleach to 2.1.3

### DIFF
--- a/requirements/env.txt
+++ b/requirements/env.txt
@@ -3,7 +3,7 @@
 Django==1.11.7
 MySQL-python==1.2.5
 Pillow==4.3.0
-bleach==2.1.1
+bleach==2.1.3
 commonware==0.5.0
 compare-locales==2.7.0
 contextlib2==0.5.5


### PR DESCRIPTION
This fixes a security bug in bleach escaping URIs containing html
entities. Already mitigated by CSP in elmo.