### PR TITLE
Tag the docker image on master, publish latest on develop

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,9 +87,31 @@ jobs:
       - run:
           name: upload docker images
           command: |
-            ./.circleci/docker-hub-upload elmo_webapp
+            if [ "${CIRCLE_BRANCH}" == "master" ] || [ -n "${CIRCLE_TAG}" ]; then
+              ./.circleci/docker-hub-upload --tag ${CIRCLE_TAG} elmo_webapp
+            if [ "${CIRCLE_BRANCH}" == "develop" ]; then
+              ./.circleci/docker-hub-upload elmo_webapp
+            fi
 
       # - save_cache:
       #     paths:
       #       - ./venv
       #     key: TBD
+
+workflows:
+  version: 2
+
+  # workflow jobs are _not_ run in tag builds by default
+  # we use filters to whitelist jobs that should be run for tags
+
+  # workflow jobs are run in _all_ branch builds by default
+  # we use filters to blacklist jobs that shouldn't be run for a branch
+
+  # see: https://circleci.com/docs/2.0/workflows/#git-tag-job-execution
+
+  build:
+    jobs:
+      - build:
+          filters:
+            tags:
+              only: /.*/


### PR DESCRIPTION
Adding a workflow to circleci to build on tags.
On master and tags, publish a tagged image.
On develop, publish latest to go to stage.

@milescrabill , @sciurus, either of your review would be great here.