### PR TITLE
Convert progress spark from static files into a dynamic CSS.

### DIFF
--- a/apps/elmo_commons/tests/mixins.py
+++ b/apps/elmo_commons/tests/mixins.py
@@ -17,7 +17,6 @@ SCRIPTS_REGEX = re.compile(
 STYLES_REGEX = re.compile('<link.*?href=["\']([^"\']+)["\'].*?>',
                           re.M | re.DOTALL)
 WHITELIST = {
-    '/static/l10nstats/progress.css',
 }
 
 

--- a/apps/homepage/templates/homepage/locale-team.html
+++ b/apps/homepage/templates/homepage/locale-team.html
@@ -28,7 +28,8 @@ var LOCALE_CODE = '{{ locale.code }}';
 <link rel="stylesheet" href="{% static "shipping/css/snippet.css" %}" type="text/css">
 <link rel="stylesheet" href="{% static "css/open-iconic.css" %}" type="text/css">
 {% endcompress %}
-<link rel="stylesheet" href="{% static "l10nstats/progress.css" %}" type="text/css">
+<link rel="stylesheet" href="{% url "progress-layout" %}" type="text/css">
+<link rel="lazy-stylesheet" href="{% url "progress-css" %}" type="text/css">
 {% endblock %}
 
 {% block alt_header %}

--- a/apps/l10nstats/templates/l10nstats/progress-layout.css
+++ b/apps/l10nstats/templates/l10nstats/progress-layout.css
@@ -1,0 +1,6 @@
+.progress-thumb {
+    width: {{ PROGRESS_IMG_SIZE.x }}px;
+    height: {{ PROGRESS_IMG_SIZE.y }}px;
+    border-bottom: solid 1px grey;
+    border-right: solid 1px grey;
+}

--- a/apps/l10nstats/templates/l10nstats/progress.css
+++ b/apps/l10nstats/templates/l10nstats/progress.css
@@ -1,10 +1,5 @@
-{% load staticfiles %}
 .progress-thumb {
-    width: {{ PROGRESS_IMG_SIZE.x }}px;
-    height: {{ PROGRESS_IMG_SIZE.y }}px;
-    background-image: url("{% static PROGRESS_BASE_NAME %}png");
-    border-bottom: solid 1px grey;
-    border-right: solid 1px grey;
+    background-image: url("{{ background_data_uri }}");
 }
 
 {% for backpos in background_positions %}

--- a/apps/l10nstats/urls.py
+++ b/apps/l10nstats/urls.py
@@ -10,10 +10,17 @@ from __future__ import unicode_literals
 from django.conf.urls import url
 from . import views
 from .views import plots, compare
+from .views.progress import ProgressView, ProgressLayout
 
 urlpatterns = [
     url(r'^$', views.index),
     url(r'^history$', plots.history_plot, name='locale-tree-history'),
     url(r'^compare$', compare.CompareView.as_view(), name='compare-locales'),
     url(r'^tree-status/([^/]+)$', plots.tree_progress, name='tree-history'),
+    url(r'^progress.css$', ProgressView.as_view(), name='progress-css'),
+    url(
+        r'^progress-layout.css$',
+        ProgressLayout.as_view(),
+        name='progress-layout'
+    ),
 ]

--- a/apps/shipping/templates/shipping/dashboard.html
+++ b/apps/shipping/templates/shipping/dashboard.html
@@ -11,9 +11,9 @@
 {% block head_matter %}
 <link rel="stylesheet" href="{% static "shipping/css/dashboard.css" %}" type="text/css">
 <link rel="stylesheet" href="{% static "css/open-iconic.css" %}" type="text/css">
-<link rel="stylesheet" href="{% static "l10nstats/progress.css" %}" type="text/css">
+<link rel="stylesheet" href="{% url "progress-layout" %}" type="text/css">
+<link rel="lazy-stylesheet" href="{% url "progress-css" %}" type="text/css">
 <link href="{% url 'shipping-status_json' %}?{{ query }}" type="application/json" rel="exhibit-data"/>
-</style>
 {% endblock %}
 
 {% block javascript_matter %}

--- a/docker/run_webapp.sh
+++ b/docker/run_webapp.sh
@@ -15,9 +15,6 @@ BUFFER_SIZE=${BUFFER_SIZE:-"16384"}
 PORT=${PORT:-"8000"}
 NUM_WORKERS=${NUM_WORKERS:-"6"}
 
-mkdir -p /app/collected/static/l10nstats
-(cd /app/ && ${CMDPREFIX} /app/env/bin/python manage.py progress)
-
 if [ "$1" == "--dev" ]; then
     # Run with manage.py
     echo "******************************************************************"

--- a/elmo/settings/base.py
+++ b/elmo/settings/base.py
@@ -153,6 +153,7 @@ CSP_FONT_SRC = ("'self'",)
 CSP_FRAME_SRC = ("https://platform.twitter.com",)
 CSP_IMG_SRC = (
     "'self'",
+    "data:",
     "https://syndication.twitter.com",
     "https://ssl.google-analytics.com",
 )
@@ -184,7 +185,6 @@ WEBDASHBOARD_URL = 'https://l10n.mozilla-community.org/webdashboard/'
 # settings for the compare-locales progress preview images
 PROGRESS_DAYS = 50
 PROGRESS_IMG_SIZE = {'x': 100, 'y': 20}
-PROGRESS_BASE_NAME = 'l10nstats/progress.'
 
 __all__ = [
     setting for setting in globals().keys() if setting.isupper()

--- a/elmo/static/js/base.js
+++ b/elmo/static/js/base.js
@@ -57,3 +57,8 @@ var gLogoutHelper = (function() {
 
     return new LogoutHelper(document.getElementById("auth"));
 })();
+
+// Some CSS can be loaded after initial paint.
+(window.requestIdleCallback || window.setTimeout)(function() {
+    document.head.querySelector('link[rel="lazy-stylesheet"]').rel = "stylesheet";
+})


### PR DESCRIPTION
This is OK now that the progress view is faster. To ensure that
the CSS and the image are aligned, we're putting both into a single
resource, by using a data uri in the CSS.

Also, load this stylesheet lazily to not block rendering, that's not required.

The layout of the thumbs is extracted into a different stylesheet.
That's still rendered as it's settings-dependent, but loaded blockingly.

As we now have a view for progress.css, remove the old static from
the WHITELIST in the includes test.