### PR TITLE
Control CSP from within elmo.

### DIFF
--- a/apps/homepage/templates/homepage/index.html
+++ b/apps/homepage/templates/homepage/index.html
@@ -20,7 +20,7 @@
 {% block javascript_matter %}
 <script src="{% static "js/libs/chosen.jquery.js" %}"></script>
 <script src="{% static "homepage/js/index.js" %}"></script>
-<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
+<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="https://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
 {% endblock %}
 
 {% block alt_header %}
@@ -38,8 +38,8 @@
         poster="{% static "img/poster.jpg" %}"
         controls="controls"
     >
-        <source src="//videos.cdn.mozilla.net/serv/drafts/FFxGlobal.webm" type="video/webm" />
-        <source src="//videos.cdn.mozilla.net/serv/drafts/FFxGlobal.mp4" type="video/mp4" />
+        <source src="https://videos.cdn.mozilla.net/serv/drafts/FFxGlobal.webm" type="video/webm" />
+        <source src="https://videos.cdn.mozilla.net/serv/drafts/FFxGlobal.mp4" type="video/mp4" />
     </video>
     <article>
         <h2>Users first, no matter where they are.</h2>

--- a/elmo/settings/base.py
+++ b/elmo/settings/base.py
@@ -75,6 +75,7 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.messages.middleware.MessageMiddleware',
     'session_csrf.CsrfMiddleware',
 
+    'csp.middleware.CSPMiddleware',
     'commonware.middleware.FrameOptionsHeader',
     'commonware.middleware.ScrubRequestOnException',
 )
@@ -143,6 +144,32 @@ STATICFILES_FINDERS = (
   'django.contrib.staticfiles.finders.FileSystemFinder',
   'django.contrib.staticfiles.finders.AppDirectoriesFinder',
   'compressor.finders.CompressorFinder',
+)
+
+# ContentSecurityPolicy, CSP
+CSP_DEFAULT_SRC = ("'none'",)
+CSP_CONNECT_SRC = ("https:", "'self'",)
+CSP_FONT_SRC = ("'self'",)
+CSP_FRAME_SRC = ("https://platform.twitter.com",)
+CSP_IMG_SRC = (
+    "'self'",
+    "https://syndication.twitter.com",
+    "https://ssl.google-analytics.com",
+)
+CSP_MEDIA_SRC = (
+    "https://videos.cdn.mozilla.net",
+    "https://videos-real-origin.cdn.mozilla.net",
+)
+CSP_SCRIPT_SRC = (
+    "'self'",
+    "'unsafe-inline'",
+    "'unsafe-eval'",
+    "https://platform.twitter.com",
+    "https://ssl.google-analytics.com/ga.js",
+)
+CSP_STYLE_SRC = (
+    "'self'",
+    "'unsafe-inline'",
 )
 
 # Feeds

--- a/requirements/env.txt
+++ b/requirements/env.txt
@@ -6,6 +6,7 @@ bleach==3.1.0
 commonware==0.5.0
 compare-locales==5.1.0
 django-compressor==2.2
+django_csp==3.5
 django-session-csrf==0.7.1
 elasticsearch==2.4.1
 feedparser==5.2.1


### PR DESCRIPTION
This is mostly the headers we used to have, with some slight
modification for unsafe local hosting, I added 'self' to
connect-src.

Also, let's not pretend we should use unsafe external resources,
and hard-code https everywhere.

I guess this should be reviewed by @sciurus.

CC @EnTeQuAk, too, thanks for that quick release turn-around.