### PR TITLE
fix build retention command

### DIFF
--- a/apps/mbdb/management/commands/build-retention.py
+++ b/apps/mbdb/management/commands/build-retention.py
@@ -13,9 +13,8 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from datetime import datetime, timedelta
 import os.path
-import tarfile
 
-from django.db.models import Min, Max
+from django.db.models import Max
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 from django.core.management import call_command
@@ -24,7 +23,7 @@ from mbdb.models import Builder, Build, Log, BuildRequest
 
 
 class Command(BaseCommand):
-    chunksize = 100
+    chunksize = 1000
     help = __doc__
     logsoffset = timedelta(days=1)
     buildoffset = timedelta(days=7)
@@ -32,18 +31,20 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument('--dry-run', '-n', action='store_true',
                             help="Dry run, don't touch files and database")
-        parser.add_argument('--backup', default=None,
-                            help="Back up logs in this directory")
         parser.add_argument(
             '--limit', default=None, type=int,
             help="Limit cycles, a cycle is %d builds" % self.chunksize
         )
+        parser.add_argument(
+            '--chunksize', default=self.chunksize, type=int, metavar='N',
+            help="Take N objects at a time"
+        )
 
     def handle(self, **options):
         dry_run = options['dry_run']
-        backup_dir = options['backup']
+        chunksize = options['chunksize']
         master_for_builder = dict(
-            Builder.objects.values_list('id', 'master__name')
+            Builder.objects.values_list('name', 'master__name')
         )
         last_builds = [
             last_build
@@ -56,83 +57,79 @@ class Command(BaseCommand):
         logtime = now - self.logsoffset
         buildtime = now - self.buildoffset
 
+        logs = (
+            Log.objects
+            .filter(step__build__endtime__lt=logtime)
+            .exclude(filename__isnull=True)
+        )
         builds = (
             Build.objects
             .exclude(id__in=last_builds)
-            .filter(endtime__lt=max(buildtime, logtime))
-            .values_list('id', 'endtime', 'buildnumber',
-                         'builder', 'builder__name')
+            .filter(endtime__lt=buildtime)
         )
-        if not dry_run and backup_dir:
-            if not os.path.isdir(backup_dir):
-                os.makedirs(backup_dir)
-        buildcount = files = objects = last_build_request = 0
-        for chunk in self.chunkBuilds(builds, options['limit']):
-            if not dry_run and backup_dir:
-                tarball = tarfile.open(
-                    name=os.path.join(
-                        backup_dir,
-                        'logs-%d-%d.tar.bz2' % (chunk[0][0], chunk[-1][0])),
-                    mode='w:bz2'
-                )
-            for buildid, endtime, buildnumber, builderid, buildername in chunk:
-                if endtime >= logtime:
-                    continue
-                mount = settings.LOG_MOUNTS[master_for_builder[builderid]]
-                logs = Log.objects.filter(step__build=buildid)
-                for log in logs:
-                    if log.filename:
-                        arcname = log.filename
-                        filename = os.path.join(mount, log.filename)
-                        if not os.path.exists(filename):
-                            filename += '.bz2'
-                            arcname += '.bz2'
-                        if os.path.exists(filename):
-                            files += 1
-                            if not dry_run:
-                                if backup_dir:
-                                    tarball.add(filename, arcname=arcname)
-                                os.remove(filename)
-                objects += logs.count()
-                if not dry_run:
-                    logs.delete()
-                    builderpath = os.path.join(
-                        mount,
-                        buildername,
-                        str(buildnumber))
-                    if os.path.exists(builderpath):
-                        os.remove(builderpath)
-            if not dry_run and backup_dir:
-                tarball.close()
-
-            buildquery = (
-                Build.objects
-                     .filter(id__in=[t[0] for t in chunk],
-                             endtime__lt=buildtime)
+        self.stdout.write(
+            'Working on {} builds and {} logs.'.format(
+                Build.objects.count(),
+                Log.objects.count(),
             )
+        )
+        buildcount = files = objects = last_build_request = 0
+        for chunk in self.chunk_query(logs, chunksize, options['limit']):
+            objects += chunk.count()
+            for filename, buildername in chunk.values_list(
+                'filename',
+                'step__build__builder__name',
+            ):
+                mount = settings.LOG_MOUNTS[master_for_builder[buildername]]
+                if filename:
+                    arcname = filename
+                    filename = os.path.join(mount, filename)
+                    if not os.path.exists(filename):
+                        filename += '.bz2'
+                        arcname += '.bz2'
+                    if os.path.exists(filename):
+                        files += 1
+                        if not dry_run:
+                            os.remove(filename)
+                if not dry_run:
+                    chunk.delete()
+        self.stdout.write('Removed %d logs with %d files\n' % (
+            objects, files
+        ))
+
+        for buildquery in self.chunk_query(
+            builds, chunksize, options['limit']
+        ):
             thiscount = buildquery.count()
             if thiscount:
                 buildcount += thiscount
-                minmax = buildquery.aggregate(min=Min('id'), max=Max('id'))
+                build_ids = list(buildquery.values_list('id', flat=True))
                 last_build_request = max(
                     last_build_request,
                     BuildRequest.objects
-                    .filter(builds__in=buildquery)
+                    .filter(builds__in=build_ids)
                     .order_by('-pk')
                     .values_list('id', flat=True)
                     .first()
                     or 0
                 )
-                if not dry_run:
-                    buildquery.delete()
-                self.stdout.write('Deleting builds from %d to %d\n' % (
-                    minmax['min'], minmax['max']
+                self.stdout.write('Deleting builds between %d and %d\n' % (
+                    min(build_ids), max(build_ids)
                 ))
-            else:
-                self.stdout.write('No builds to delete in this chunk\n')
-        self.stdout.write('Removed %d logs with %d files\n' % (
-            objects, files
-        ))
+                if dry_run:
+                    continue
+                for buildername, buildnumber in buildquery.values_list(
+                    'builder__name',
+                    'buildnumber',
+                ):
+                    builderpath = os.path.join(
+                        settings.LOG_MOUNTS[master_for_builder[buildername]],
+                        buildername,
+                        str(buildnumber))
+                    if os.path.exists(builderpath):
+                        os.remove(builderpath)
+                        files += 1
+                buildquery.delete()
         self.stdout.write('Removed %d builds\n' % buildcount)
         if dry_run:
             self.stdout.write(
@@ -148,7 +145,13 @@ class Command(BaseCommand):
                 )
                 .delete()
             )
-            self.stdout.write('Remove %d build requests\n' % brc)
+            self.stdout.write('Removed %d build requests\n' % brc)
+            self.stdout.write(
+                '{} builds and {} logs kept.'.format(
+                    Build.objects.count(),
+                    Log.objects.count(),
+                )
+            )
         if dry_run:
             # skip clean_builds
             return
@@ -161,17 +164,21 @@ class Command(BaseCommand):
         except CommandError:
             pass
 
-    def chunkBuilds(self, q, limit):
+    def chunk_query(self, q, chunksize, limit):
         q = q.order_by('id')
-        start = 0
+        last_id = None
         if limit is not None and limit <= 0:
             limit = None
         while True:
-            result = list(q.filter(id__gt=start)[:self.chunksize])
-            if not result:
+            this_query = q
+            if last_id is not None:
+                this_query = this_query.filter(id__gt=last_id)
+            last_id = this_query[:chunksize].aggregate(max=Max('id'))['max']
+            if last_id is not None:
+                this_query = this_query.filter(id__lte=last_id)
+            yield this_query
+            if last_id is None:
                 break
-            start = result[-1][0]
-            yield result
             if limit is not None:
                 limit -= 1
                 if not limit:


### PR DESCRIPTION
BuildRequest objects are really only important on build start, so I'm keeping
track of the last build request which is bound to one of the builds I delete
in retention. Then I delete all orphaned BuildRequest objects up to that one.

I also hook up clean_builds, but I tolerate that failing.