### PR TITLE
bug 1597053, be vigilant about bytestrings coming out of hglib, r=adrian

### DIFF
--- a/apps/pushes/tests/test_diff.py
+++ b/apps/pushes/tests/test_diff.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -42,7 +43,7 @@ class DiffTestCase(RepoTestBase):
             hgrepo.addremove()
             hgrepo.commit(user="Jane Doe <jdoe@foo.tld>",
                           message="initial commit")
-            rev0 = hgrepo[0].node()
+            rev0 = hgrepo[0].node().decode('ascii')
 
         Repository.objects.create(
             name=self.repo_name,
@@ -74,7 +75,7 @@ class DiffTestCase(RepoTestBase):
             hgrepo.commit(user="Jane Doe <jdoe@foo.tld>",
                           message="initial commit",
                           addremove=True)
-            rev0 = hgrepo[0].node()
+            rev0 = hgrepo[0].node().decode('ascii')
 
             # do this to trigger an exception on Mozilla.Parser.readContents
             _content = '<!ENTITY key1 "Hell\xe3">\n'
@@ -83,7 +84,7 @@ class DiffTestCase(RepoTestBase):
 
             hgrepo.commit(user="Jane Doe <jdoe@foo.tld>",
                           message="Second commit")
-            rev1 = hgrepo[1].node()
+            rev1 = hgrepo[1].node().decode('ascii')
 
         repo_url = 'http://localhost:8001/' + self.repo_name + '/'
         Repository.objects.create(
@@ -110,6 +111,20 @@ class DiffTestCase(RepoTestBase):
             'repo': self.repo_name,
             'from': rev0,
             'to': 'xxx'
+        })
+        self.assertEqual(response.status_code, 400)
+
+        response = self.client.get(url, {
+            'repo': self.repo_name,
+            'from': 'ßüper',
+            'to': rev1
+        })
+        self.assertEqual(response.status_code, 400)
+
+        response = self.client.get(url, {
+            'repo': self.repo_name,
+            'from': rev0,
+            'to': 'ßüper'
         })
         self.assertEqual(response.status_code, 400)
 

--- a/apps/pushes/tests/test_pushes.py
+++ b/apps/pushes/tests/test_pushes.py
@@ -47,7 +47,7 @@ class TestHandlePushes(RepoTestBase):
             hgrepo.commit(user="Jane Doe <jdoe@foo.tld>",
                           message="initial commit",
                           addremove=True)
-            rev0 = hgrepo[0].node()
+            rev0 = hgrepo[0].node().decode('ascii')
 
         timestamp = int(time.time())
         push_id = 100
@@ -75,7 +75,7 @@ class TestHandlePushes(RepoTestBase):
 
         self.assertEqual(changeset.description, 'initial commit')
         self.assertEqual(changeset.user, 'Jane Doe <jdoe@foo.tld>')
-        self.assertEqual(hglib.util.b(changeset.revision), rev0)
+        self.assertEqual(changeset.revision, rev0)
         self.assertEqual(changeset.branch, branch)
 
         self.assertEqual(branch.name, 'default')
@@ -96,7 +96,7 @@ class TestHandlePushes(RepoTestBase):
             hgrepo.commit(user="Jane Doe <jdoe@foo.tld>",
                           message="initial commit",
                           addremove=True)
-            rev0 = hgrepo[0].node()
+            rev0 = hgrepo[0].node().decode('ascii')
 
         timestamp = int(time.time())
         pushjs0 = PushJS(100, {
@@ -124,7 +124,7 @@ class TestHandlePushes(RepoTestBase):
             hgrepo.commit(user="Jane Doe <jdoe@foo.tld>",
                           message="initial commit",
                           addremove=True)
-            rev0 = hgrepo[0].node()
+            rev0 = hgrepo[0].node().decode('ascii')
 
         timestamp = int(time.time())
         pushjs0 = PushJS(100, {
@@ -153,7 +153,7 @@ class TestHandlePushes(RepoTestBase):
             hgrepo.commit(user="Jane Doe <jdoe@foo.tld>",
                           message="initial commit",
                           addremove=True)
-            rev0 = hgrepo[0].node()
+            rev0 = hgrepo[0].node().decode('ascii')
 
         timestamp = int(time.time())
         pushjs0 = PushJS(100, {
@@ -190,7 +190,7 @@ class TestHandlePushes(RepoTestBase):
             hgrepo.commit(user="Jane Doe <jdoe@foo.tld>",
                           message="initial commit",
                           addremove=True)
-            rev0 = hgrepo[0].node()
+            rev0 = hgrepo[0].node().decode('ascii')
 
         timestamp = int(time.time())
         pushjs0 = PushJS(100, {
@@ -217,7 +217,7 @@ class TestHandlePushes(RepoTestBase):
             hgrepo.commit(user="Jane Doe <jdoe@foo.tld>",
                           message="initial commit",
                           addremove=True)
-            rev0 = hgrepo[0].node()
+            rev0 = hgrepo[0].node().decode('ascii')
 
             timestamp = int(time.time())
             pushjs0 = PushJS(100, {
@@ -235,7 +235,7 @@ class TestHandlePushes(RepoTestBase):
                 ''')
             hgrepo.commit(user="Jane Doe <jdoe@foo.tld>",
                           message="Second commit")
-            rev1 = hgrepo[1].node()
+            rev1 = hgrepo[1].node().decode('ascii')
 
         # a second time
         timestamp = int(time.time())

--- a/apps/pushes/views/diff.py
+++ b/apps/pushes/views/diff.py
@@ -120,11 +120,11 @@ class DiffView(View):
         '''
         try:
             self.rev1 = self.real_rev(_from)
-        except KeyError:
+        except (KeyError, UnicodeEncodeError):
             raise BadRevision("Unrecognized 'from' parameter")
         try:
             self.rev2 = self.real_rev(_to)
-        except KeyError:
+        except (KeyError, UnicodeEncodeError):
             raise BadRevision("Unrecognized 'to' parameter")
         changed = []
         added = []
@@ -179,10 +179,9 @@ class DiffView(View):
                    .filter(branch=1)  # default branch
                    .order_by('-pk')
                    .values_list('revision', flat=True)[0])
-        # Convert the 'from' and 'to' to strings (instead of unicode)
-        # in case mercurial needs to look for the key in binary data.
-        # This prevents UnicodeWarning messages.
-        ctx = self.client[str(rev)]
+        # Convert the 'from' and 'to' to bytestrings
+        # which is what hglib expexts.
+        ctx = self.client[rev.encode('ascii')]
         return ctx.node()
 
     @metrics.timer_decorator('diff.file')


### PR DESCRIPTION
Adding a bytestring to the db in django 2.x gives "b'my byte string'".
For hex revisions, use ascii encoding, and for user-data utf-8.

Interestingly, this is getting me to pass tests up to django 2.2.x now. There's some things in the 2.1 realm that Pontoon will need, https://docs.djangoproject.com/en/3.0/releases/2.1/#features-removed-in-2-1 highlights the `django.contrib.auth.views.login` and friends, which Pontoon still uses, for example.