### PR TITLE
Feature/backport pushes utils

### DIFF
--- a/apps/pushes/tests/test_pushes.py
+++ b/apps/pushes/tests/test_pushes.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import datetime
+import mock
 import time
 from elmo.test import TestCase
 from django.urls import reverse
@@ -27,6 +28,7 @@ class PushesTestCase(TestCase, EmbedsTestCaseMixin):
         # like I said, a very basic test
 
 
+@mock.patch('pushes.utils.logging', mock.MagicMock())
 class TestHandlePushes(RepoTestBase):
 
     repo_name = 'mozilla-central-original'

--- a/apps/pushes/utils.py
+++ b/apps/pushes/utils.py
@@ -27,7 +27,7 @@ from markus.utils import generate_tag
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(message)s")
 logger = logging.getLogger()
-metrics = markus.get_metrics('elmo-hg-worker')
+metrics = markus.get_metrics('hg.worker')
 
 
 def getURL(repo, limit):

--- a/apps/pushes/utils.py
+++ b/apps/pushes/utils.py
@@ -160,6 +160,9 @@ def _handlePushes(
             p.save()
         repo.save()
     hgrepo.close()
+    logging.info('handlePushes took {}'.format(
+        datetime.utcnow().replace(microsecond=0) - now
+    ))
     return len(submits)
 
 

--- a/apps/pushes/utils.py
+++ b/apps/pushes/utils.py
@@ -166,9 +166,9 @@ def _handlePushes(
 def _ensure_hg_repository_sync(repo, do_update=False):
     logging.info('hg clone/update start for {}'.format(repo.name))
     now = datetime.utcnow().replace(microsecond=0)
-    tags = [generate_tag(repo.name)]
+    tags = [generate_tag('repo', repo.name)]
     if repo.forest:
-        tags.append(generate_tag(repo.forest.name))
+        tags.append(generate_tag('forest', repo.forest.name))
     repopath = repo.local_path()
     try:
         with metrics.timer('hg-pull', tags=tags):
@@ -205,13 +205,13 @@ def _ensure_hg_repository_sync(repo, do_update=False):
             .exclude(archived=True)
             .exclude(id=repo.id)
         )
-    tags.append('full-clone')
+    tags.append(generate_tag('clone_type', 'full-clone'))
     logging.info('Cloning from {}'.format(str(repo.url)))
     with metrics.timer('hg-pull', tags=tags):
         hgrepo = _hg_repository_sync(repopath, repo.url,
                                      do_update=do_update)
     for other in other_repos:
-        tags[0] = generate_tag(other.name)
+        tags[0] = generate_tag('repo', other.name)
         logging.info('Pulling from {}'.format(str(other.url)))
         with metrics.timer('hg-pull', tags=tags):
             hgrepo.pull(source=str(other.url))

--- a/apps/pushes/utils.py
+++ b/apps/pushes/utils.py
@@ -9,16 +9,25 @@ from __future__ import unicode_literals
 
 from datetime import datetime
 import json
+import logging
 import os.path
 import six.moves.urllib.request
 import six.moves.urllib.error
 import six.moves.urllib.parse
 from six.moves import range
 from functools import reduce
+import shutil
 import hglib
 
 from life.models import Repository, Push, Changeset, Branch, File
 from django.db import transaction, connection
+import markus
+from markus.utils import generate_tag
+
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(message)s")
+logger = logging.getLogger()
+metrics = markus.get_metrics('elmo-hg-worker')
 
 
 def getURL(repo, limit):
@@ -111,7 +120,7 @@ def handlePushes(repo_id, submits, do_update=False, close_connection=False):
         # maybe we lost the connection, close it to make sure we get a new one
         connection.close()
     repo = Repository.objects.get(id=repo_id)
-    with _hg_repository_sync(
+    with _ensure_hg_repository_sync(
         repo.local_path(), repo.url, do_update=do_update
     ) as hgrepo:
         return _handlePushes(
@@ -152,6 +161,64 @@ def _handlePushes(
         repo.save()
     hgrepo.close()
     return len(submits)
+
+
+def _ensure_hg_repository_sync(repo, do_update=False):
+    logging.info('hg clone/update start for {}'.format(repo.name))
+    now = datetime.utcnow().replace(microsecond=0)
+    tags = [generate_tag(repo.name)]
+    if repo.forest:
+        tags.append(generate_tag(repo.forest.name))
+    repopath = repo.local_path()
+    try:
+        with metrics.timer('hg-pull', tags=tags):
+            return _hg_repository_sync(repopath, repo.url,
+                                       do_update=do_update)
+    except Exception as e:
+        logging.error('Clone/update failed, {}'.format(e))
+    # something went wrong, let's just try again
+    # nuke what we had
+    if os.path.exists(repopath):
+        shutil.rmtree(repopath, ignore_errors=True)
+        logging.error('Removed {}'.format(repopath))
+    # now we need to create a clone and then pull all other origins
+    other_repos = repo.forks.all()
+    if repo.forest and repo.forest.fork_of:
+        forests = [repo.forest.fork_of]
+        forests.extend(
+            repo.forest.fork_of
+            .forks
+            .exclude(archived=True)
+            .exclude(repo.forest)
+        )
+        other_repos = (
+            Repository.objects
+            .filter(forest__in=forests)
+            .filter(locale=repo.locale)
+            .exclude(archived=True)
+        )
+    elif repo.fork_of:
+        other_repos = [repo.fork_of]
+        other_repos.extend(
+            repo.fork_of
+            .forks
+            .exclude(archived=True)
+            .exclude(id=repo.id)
+        )
+    tags.append('full-clone')
+    logging.info('Cloning from {}'.format(str(repo.url)))
+    with metrics.timer('hg-pull', tags=tags):
+        hgrepo = _hg_repository_sync(repopath, repo.url,
+                                     do_update=do_update)
+    for other in other_repos:
+        tags[0] = generate_tag(other.name)
+        logging.info('Pulling from {}'.format(str(other.url)))
+        with metrics.timer('hg-pull', tags=tags):
+            hgrepo.pull(source=str(other.url))
+    logging.info('hg clone/update took {}'.format(
+        datetime.utcnow().replace(microsecond=0) - now
+    ))
+    return hgrepo
 
 
 def _hg_repository_sync(repopath, url, do_update=False):

--- a/apps/pushes/utils.py
+++ b/apps/pushes/utils.py
@@ -25,8 +25,6 @@ import markus
 from markus.utils import generate_tag
 
 
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(message)s")
-logger = logging.getLogger()
 metrics = markus.get_metrics('hg.worker')
 
 
@@ -121,7 +119,7 @@ def handlePushes(repo_id, submits, do_update=False, close_connection=False):
         connection.close()
     repo = Repository.objects.get(id=repo_id)
     with _ensure_hg_repository_sync(
-        repo.local_path(), repo.url, do_update=do_update
+        repo, do_update=do_update
     ) as hgrepo:
         return _handlePushes(
             repo, hgrepo, repo_id, submits,

--- a/apps/pushes/utils.py
+++ b/apps/pushes/utils.py
@@ -132,6 +132,7 @@ def handlePushes(repo_id, submits, do_update=False, close_connection=False):
 def _handlePushes(
     repo, hgrepo, repo_id, submits, do_update=False, close_connection=False
 ):
+    now = datetime.utcnow().replace(microsecond=0)
     revs = reduce(
         lambda r, l: r+l,
         (data.changesets for data in submits),


### PR DESCRIPTION
Brian, as you've been involved in the code changes on the a10n side, would you be willing to rubber stamp this?

I left the commit messages from https://github.com/mozilla-services/elmo-automation/commits/master/a10n/hg_elmo/utils.py, so you can see how they map.

The `Update Django to 1.11.x` commit there was the last time I had sync'ed between elmo and a10n before. That matches the `Django Deprecations` commit in https://github.com/mozilla/elmo/commits/master/apps/pushes/utils.py.