### PR TITLE
Migrate from master/slave vocabulary

### DIFF
--- a/apps/elmo_commons/management/commands/mothball.py
+++ b/apps/elmo_commons/management/commands/mothball.py
@@ -62,11 +62,11 @@ class Repl(cmd.Cmd):
         self.stdout.write('Deleting log files and objects\n')
         # WARNING(assumption):
         # Let's rule out that Runs could be associated with multiple
-        # Builders, and thus Masters.
-        master = (builds
-                  .values_list('builder__master__name', flat=True)
+        # Builders, and thus Mains.
+        main = (builds
+                  .values_list('builder__main__name', flat=True)
                   .distinct())[0]
-        base = settings.LOG_MOUNTS[master]
+        base = settings.LOG_MOUNTS[main]
         for f in (logs
                   .exclude(filename=None)
                   .values_list('filename', flat=True)):

--- a/apps/elmo_commons/migrations/0001_clean_contenttypes.py
+++ b/apps/elmo_commons/migrations/0001_clean_contenttypes.py
@@ -35,7 +35,7 @@ class Migration(migrations.Migration):
         ('mbdb', '0003_bug_1353850_on_delete'),
         ('privacy', '0001_initial'),
         ('shipping', '0003_auto_20160729_1128'),
-        ('tinder', '0002_drop_mastermap')
+        ('tinder', '0002_drop_mainmap')
     ]
 
     operations = [

--- a/apps/l10nstats/management/commands/deactivate.py
+++ b/apps/l10nstats/management/commands/deactivate.py
@@ -22,7 +22,7 @@ class Command(BaseCommand):
     def handleApps(self, **kwargs):
         l10nbuilds = urlopen(
             'https://raw.githubusercontent.com/Pike/master-ball/'
-            'master/l10n-master/l10nbuilds.ini')
+            'main/l10n-main/l10nbuilds.ini')
         cp = ConfigParser()
         cp.readfp(l10nbuilds)
         for section in cp.sections():

--- a/apps/l10nstats/management/commands/uploadcompares.py
+++ b/apps/l10nstats/management/commands/uploadcompares.py
@@ -18,7 +18,7 @@ import six
 from six.moves import range
 
 from l10nstats.models import Run
-from mbdb.models import Master, Log, Step
+from mbdb.models import Main, Log, Step
 from tinder.views import generateLog, NoLogFile
 from .. import LoggingCommand
 
@@ -45,11 +45,11 @@ class Command(LoggingCommand):
         ):
             raise CommandError('LOG_MOUNTS is not a dict in settings')
 
-        for master in Master.objects.order_by('-pk').values_list('name',
+        for main in Main.objects.order_by('-pk').values_list('name',
                                                                  flat=True):
-            if master not in settings.LOG_MOUNTS:
+            if main not in settings.LOG_MOUNTS:
                 raise CommandError('settings.LOG_MOUNTS not defined for %s' %
-                                   master)
+                                   main)
         self.chunksize = options['chunksize']
         self.es = elasticsearch.Elasticsearch(**settings.ES_KWARGS)
         self.index = settings.ES_COMPARE_INDEX
@@ -111,9 +111,9 @@ class Command(LoggingCommand):
                 raise CommandError('failed %d docs' % len(errors))
 
     def generateDocs(self, runs):
-        run_master = dict(runs
+        run_main = dict(runs
                           .values_list('id',
-                                       'build__builder__master__name'))
+                                       'build__builder__main__name'))
         for run in runs:
             self.offset = run.id
             data = ''
@@ -122,7 +122,7 @@ class Command(LoggingCommand):
                                  build__run=run)):
                 for log in step.logs.all():
                     try:
-                        for chunk in generateLog(run_master[run.id],
+                        for chunk in generateLog(run_main[run.id],
                                                  log.filename,
                                                  channels=(Log.JSON,)):
                             data += chunk['data']

--- a/apps/mbdb/management/commands/build-retention.py
+++ b/apps/mbdb/management/commands/build-retention.py
@@ -25,7 +25,7 @@ from mbdb.models import Builder, Build, Log, BuildRequest
 
 def return_if_running(cmd):
     # Pick a lock file path on the shared disc.
-    # The LOG_MOUNTS end in either test-master or l10n-master, use their
+    # The LOG_MOUNTS end in either test-main or l10n-main, use their
     # parent dir.
     lock_path = os.path.dirname(list(settings.LOG_MOUNTS.values())[0])
     lock_path = os.path.join(lock_path, 'build-retention.lck')
@@ -100,8 +100,8 @@ class Command(BaseCommand):
         else:
             # os.stat raises the same errors as os.remove, let's build on that.
             unlink = os.stat
-        master_for_builder = dict(
-            Builder.objects.values_list('name', 'master__name')
+        main_for_builder = dict(
+            Builder.objects.values_list('name', 'main__name')
         )
         last_builds = [
             last_build
@@ -143,7 +143,7 @@ class Command(BaseCommand):
                 'filename',
                 'step__build__builder__name',
             ):
-                mount = settings.LOG_MOUNTS[master_for_builder[buildername]]
+                mount = settings.LOG_MOUNTS[main_for_builder[buildername]]
                 filename = os.path.join(mount, filename)
                 try:
                     unlink(filename)
@@ -187,7 +187,7 @@ class Command(BaseCommand):
                     'buildnumber',
                 ):
                     builderpath = os.path.join(
-                        settings.LOG_MOUNTS[master_for_builder[buildername]],
+                        settings.LOG_MOUNTS[main_for_builder[buildername]],
                         buildername,
                         str(buildnumber))
                     try:
@@ -226,7 +226,7 @@ class Command(BaseCommand):
             # skip clean_builds
             return
         # Let's try to run clean_builds.
-        # This might error if our master isn't idle, but that's OK, we'll
+        # This might error if our main isn't idle, but that's OK, we'll
         # clean up the rest next time.
         # Only the BuildRequests were really important.
         try:

--- a/apps/mbdb/migrations/0001_squashed_0003_bug_1353850_on_delete.py
+++ b/apps/mbdb/migrations/0001_squashed_0003_bug_1353850_on_delete.py
@@ -76,7 +76,7 @@ class Migration(migrations.Migration):
             ],
         ),
         migrations.CreateModel(
-            name='Master',
+            name='Main',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('name', models.CharField(max_length=100, unique=True)),
@@ -100,7 +100,7 @@ class Migration(migrations.Migration):
             ],
         ),
         migrations.CreateModel(
-            name='Slave',
+            name='Subordinate',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('name', models.CharField(max_length=150, unique=True)),
@@ -161,8 +161,8 @@ class Migration(migrations.Migration):
         ),
         migrations.AddField(
             model_name='change',
-            name='master',
-            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='mbdb.Master'),
+            name='main',
+            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='mbdb.Main'),
         ),
         migrations.AddField(
             model_name='change',
@@ -171,7 +171,7 @@ class Migration(migrations.Migration):
         ),
         migrations.AlterUniqueTogether(
             name='change',
-            unique_together=set([('number', 'master')]),
+            unique_together=set([('number', 'main')]),
         ),
         migrations.AddField(
             model_name='buildrequest',
@@ -180,8 +180,8 @@ class Migration(migrations.Migration):
         ),
         migrations.AddField(
             model_name='builder',
-            name='master',
-            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='builders', to='mbdb.Master'),
+            name='main',
+            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='builders', to='mbdb.Main'),
         ),
         migrations.AddField(
             model_name='build',
@@ -195,8 +195,8 @@ class Migration(migrations.Migration):
         ),
         migrations.AddField(
             model_name='build',
-            name='slave',
-            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, to='mbdb.Slave'),
+            name='subordinate',
+            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, to='mbdb.Subordinate'),
         ),
         migrations.AddField(
             model_name='build',

--- a/apps/mbdb/models.py
+++ b/apps/mbdb/models.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-'''Models representing statuses of buildbot builds on multiple masters.
+'''Models representing statuses of buildbot builds on multiple mains.
 '''
 from __future__ import absolute_import
 from __future__ import unicode_literals
@@ -15,8 +15,8 @@ import six
 
 
 @python_2_unicode_compatible
-class Master(models.Model):
-    """Model for a buildbot master"""
+class Main(models.Model):
+    """Model for a buildbot main"""
     name = models.CharField(max_length=100, unique=True)
 
     def __str__(self):
@@ -24,8 +24,8 @@ class Master(models.Model):
 
 
 @python_2_unicode_compatible
-class Slave(models.Model):
-    """Model for a build slave"""
+class Subordinate(models.Model):
+    """Model for a build subordinate"""
     name = models.CharField(max_length=150, unique=True)
 
     def __str__(self):
@@ -55,7 +55,7 @@ class Tag(models.Model):
 class Change(models.Model):
     """Model for buildbot.changes.changes.Change"""
     number = models.PositiveIntegerField()
-    master = models.ForeignKey(Master, on_delete=models.CASCADE)
+    main = models.ForeignKey(Main, on_delete=models.CASCADE)
     branch = models.CharField(max_length=100, null=True, blank=True)
     revision = models.CharField(max_length=50, null=True, blank=True)
     who = models.CharField(max_length=100, null=True, blank=True,
@@ -66,7 +66,7 @@ class Change(models.Model):
     tags = models.ManyToManyField(Tag)
 
     class Meta:
-        unique_together = (('number', 'master'),)
+        unique_together = (('number', 'main'),)
 
     def __str__(self):
         rv = 'Change %d' % self.number
@@ -127,7 +127,7 @@ class Property(models.Model):
 class Builder(models.Model):
     """Model for buildbot.status.builder.BuilderStatus"""
     name = models.CharField(max_length=50, unique=True, db_index=True)
-    master = models.ForeignKey(Master, related_name='builders',
+    main = models.ForeignKey(Main, related_name='builders',
                                on_delete=models.CASCADE)
     category = models.CharField(max_length=30, null=True, blank=True,
                                 db_index=True)
@@ -145,7 +145,7 @@ class Build(models.Model):
     properties = models.ManyToManyField(Property, related_name='builds')
     builder = models.ForeignKey(Builder, related_name='builds',
                                 on_delete=models.CASCADE)
-    slave = models.ForeignKey(Slave, null=True, blank=True,
+    subordinate = models.ForeignKey(Subordinate, null=True, blank=True,
                               on_delete=models.SET_NULL)
     starttime = models.DateTimeField(null=True, blank=True)
     endtime = models.DateTimeField(null=True, blank=True)

--- a/apps/mbdb/tests/test_models.py
+++ b/apps/mbdb/tests/test_models.py
@@ -14,7 +14,7 @@ import six
 from six.moves import StringIO
 from elmo.test import TestCase
 from django.core import management
-from mbdb.models import Property, Step, Build, Builder, Master, Slave
+from mbdb.models import Property, Step, Build, Builder, Main, Subordinate
 
 
 class TestCustomDataType(str):
@@ -78,23 +78,23 @@ class ModelsTest(TestCase):
 
     def testStepModel(self):
         # pre-requisites
-        master = Master.objects.create(
+        main = Main.objects.create(
          name='head',
         )
 
         builder = Builder.objects.create(
           name='builder1',
-          master=master,
+          main=main,
         )
 
-        slave = Slave.objects.create(
-          name='slave 1',
+        subordinate = Subordinate.objects.create(
+          name='subordinate 1',
         )
 
         build = Build.objects.create(
           buildnumber=1,
           builder=builder,
-          slave=slave,
+          subordinate=subordinate,
           starttime=datetime.datetime.utcnow(),
           endtime=datetime.datetime.utcnow(),
           result=1,

--- a/apps/tinder/migrations/0001_squashed_0002_drop_mastermap.py
+++ b/apps/tinder/migrations/0001_squashed_0002_drop_mastermap.py
@@ -7,7 +7,7 @@ from django.db import migrations
 
 class Migration(migrations.Migration):
 
-    replaces = [('tinder', '0001_initial'), ('tinder', '0002_drop_mastermap')]
+    replaces = [('tinder', '0001_initial'), ('tinder', '0002_drop_mainmap')]
 
     initial = True
 

--- a/apps/tinder/templatetags/build_extras.py
+++ b/apps/tinder/templatetags/build_extras.py
@@ -42,7 +42,7 @@ def showbuild(build_or_step, autoescape=None):
                         args=[build.builder.name, build.buildnumber])
         rv = fmt % (b_url, build.starttime.isoformat(), build.buildnumber,
                     build.getProperty('tree'), build.getProperty('locale'))
-        rv += '<br/>%s' % build.slave.name
+        rv += '<br/>%s' % build.subordinate.name
         if build.sourcestamp.changes.count():
             fmt = ('<a href="' +
                    reverse(tinder.views.builds_for_change) +

--- a/apps/tinder/tests.py
+++ b/apps/tinder/tests.py
@@ -17,8 +17,8 @@ from django.urls import reverse
 from django.test import override_settings
 from django.test.client import Client
 from django.utils.encoding import force_text
-from mbdb.models import (Build, Change, Master, Log, Property, SourceStamp,
-                         Builder, Slave)
+from mbdb.models import (Build, Change, Main, Log, Property, SourceStamp,
+                         Builder, Subordinate)
 import tinder.views
 from tinder.views import _waterfall, LogMountKeyError
 from tinder.templatetags import build_extras
@@ -241,11 +241,11 @@ class ViewsTestCase(TestCase, EmbedsTestCaseMixin):
 
         ss = SourceStamp.objects.all()[0]
         builder = Builder.objects.all()[0]
-        slave = Slave.objects.all()[0]
+        subordinate = Subordinate.objects.all()[0]
         build1 = Build.objects.create(
           buildnumber=1,
           builder=builder,
-          slave=slave,
+          subordinate=subordinate,
           sourcestamp=ss,
         )
         build1.properties.add(prop1)
@@ -253,7 +253,7 @@ class ViewsTestCase(TestCase, EmbedsTestCaseMixin):
         build2 = Build.objects.create(
           buildnumber=2,
           builder=builder,
-          slave=slave,
+          subordinate=subordinate,
           sourcestamp=ss,
         )
         build2.properties.add(prop2)
@@ -262,7 +262,7 @@ class ViewsTestCase(TestCase, EmbedsTestCaseMixin):
         build3 = Build.objects.create(
           buildnumber=3,
           builder=builder,
-          slave=slave,
+          subordinate=subordinate,
           sourcestamp=ss,
         )
         build3.properties.add(prop1)
@@ -297,7 +297,7 @@ class ViewsTestCase(TestCase, EmbedsTestCaseMixin):
         """Test that showlog shows headers, stdout, stderr,
         with the right CSS classes, but not data from other channels like json.
         """
-        master = Master.objects.all()[0]
+        main = Main.objects.all()[0]
 
         build = Build.objects.all()[0]
         step = build.steps.all()[0]
@@ -311,7 +311,7 @@ class ViewsTestCase(TestCase, EmbedsTestCaseMixin):
         with open(os.path.join(self.temp_directory, log.filename), 'w') as f:
             f.write(SAMPLE_BUILD_LOG_PAYLOAD)
 
-        with override_settings(LOG_MOUNTS={master.name: self.temp_directory}):
+        with override_settings(LOG_MOUNTS={main.name: self.temp_directory}):
             response = self.client.get(url)
         content = force_text(response.content)
         content = content.split('</header>')[1].split('</footer')[0]
@@ -331,7 +331,7 @@ class ViewsTestCase(TestCase, EmbedsTestCaseMixin):
         """Test that showlog shows headers, stdout, stderr,
         with the right CSS classes, but not data from other channels like json.
         """
-        master = Master.objects.all()[0]
+        main = Main.objects.all()[0]
 
         build = Build.objects.all()[0]
         step = build.steps.all()[0]
@@ -347,7 +347,7 @@ class ViewsTestCase(TestCase, EmbedsTestCaseMixin):
         ) as f:
             f.write(bz2.compress(SAMPLE_BUILD_LOG_PAYLOAD.encode('utf-8')))
 
-        with override_settings(LOG_MOUNTS={master.name: self.temp_directory}):
+        with override_settings(LOG_MOUNTS={main.name: self.temp_directory}):
             response = self.client.get(url)
         content = force_text(response.content)
         content = content.split('</header>')[1].split('</footer')[0]
@@ -363,7 +363,7 @@ class ViewsTestCase(TestCase, EmbedsTestCaseMixin):
             content)
         self.assertNotIn('json', content)
 
-    def test_showlog_invalid_master(self):
+    def test_showlog_invalid_main(self):
         build = Build.objects.all()[0]
         step = build.steps.all()[0]
         log = Log.objects.create(

--- a/bb2mbdb/utils.py
+++ b/bb2mbdb/utils.py
@@ -21,12 +21,12 @@ def timeHelper(t):
 
 
 @transaction.atomic
-def modelForChange(master, change):
+def modelForChange(main, change):
     try:
-        dbchange = Change.objects.get(master=master, number=change.number)
+        dbchange = Change.objects.get(main=main, number=change.number)
         return dbchange
     except Change.DoesNotExist:
-        dbchange = Change.objects.create(master=master, number=change.number,
+        dbchange = Change.objects.create(main=main, number=change.number,
                                          when=timeHelper(change.when))
         for prop in ('branch', 'revision', 'who', 'comments'):
             val = getattr(change, prop)
@@ -47,10 +47,10 @@ def modelForChange(master, change):
 
 
 @transaction.atomic
-def modelForSource(master, source, maxChanges=4):
+def modelForSource(main, source, maxChanges=4):
     '''Get a db model for a buildbot SourceStamp.
 
-    master is the db model for the buildbot master, source is the
+    main is the db model for the buildbot main, source is the
     buildbot SourceStamp object.
     Optional argument maxChanges limits how many changes are part
     of the db query. All changes will be checked, this is just
@@ -61,7 +61,7 @@ def modelForSource(master, source, maxChanges=4):
     q = SourceStamp.objects.filter(branch=source.branch,
                                    revision=source.revision)
     if len(source.changes):
-        q = q.filter(numbered_changes__change__master=master)
+        q = q.filter(numbered_changes__change__main=main)
     for i, change in enumerate(source.changes[:maxChanges]):
         q = q.filter(numbered_changes__number=i,
                      numbered_changes__change__number=change.number)
@@ -85,7 +85,7 @@ def modelForSource(master, source, maxChanges=4):
     ss = SourceStamp.objects.create(branch=source.branch,
                                     revision=source.revision)
     for i, change in enumerate(source.changes):
-        cm = modelForChange(master, change)
+        cm = modelForChange(main, change)
         ss.numbered_changes.create(change=cm, number=i)
     ss.save()
     return ss

--- a/elmo/settings/__init__.py
+++ b/elmo/settings/__init__.py
@@ -72,8 +72,8 @@ for local_var, env_var in (
 if 'ELMO_BUILD_BASE' in os.environ:
     _log_base = os.environ['ELMO_BUILD_BASE']
     LOG_MOUNTS = {
-      'l10n-master': _log_base + '/l10n-master',
-      'test-master': _log_base + '/test-master',
+      'l10n-main': _log_base + '/l10n-main',
+      'test-main': _log_base + '/test-main',
     }
 
 if 'ELMO_SENTRY_DSN' in os.environ:


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.